### PR TITLE
Use relative URLs for imports

### DIFF
--- a/classes/terraindocument.js
+++ b/classes/terraindocument.js
@@ -1,5 +1,5 @@
-import * as fields from "/common/data/fields.mjs";
-import { Document, DocumentData } from "/common/abstract/module.mjs";
+import * as fields from "../../../common/data/fields.mjs";
+import { Document, DocumentData } from "../../../common/abstract/module.mjs";
 import { makeid, log, error, i18n, setting } from '../terrain-main.js';
 import { Terrain } from './terrain.js';
 

--- a/classes/terrainlayer.js
+++ b/classes/terrainlayer.js
@@ -3,7 +3,7 @@ import { TerrainConfig } from './terrainconfig.js';
 import { TerrainHUD } from './terrainhud.js';
 import { TerrainDocument, TerrainData } from './terraindocument.js';
 import { makeid, log, debug, warn, error, i18n, setting } from '../terrain-main.js';
-import EmbeddedCollection from "/common/abstract/embedded-collection.mjs";
+import EmbeddedCollection from "../../../common/abstract/embedded-collection.mjs";
 
 /*export let terraintypes = key => {
     return canvas.terrain.getTerrainTypes();


### PR DESCRIPTION
Several JS files import from the Foundry VTT core using absolute paths. These imports break, however, if FVTT is served from somewhere other than the root directory (using `routePrefix` in `options.json`), leading to 404 errors in the console and broken functionality.

Making the URLs relative to the file's location should fix this to work regardless of any route prefix.