### PR TITLE
Terrain elevation

### DIFF
--- a/classes/terrain.js
+++ b/classes/terrain.js
@@ -54,6 +54,7 @@ export class Terrain extends PlaceableObject {
             multiple: this.layer.defaultmultiple,
             min: 0,
             max: 0,
+            elevation: 0,
             environment: canvas.scene.getFlag('enhanced-terrain-layer', 'environment') || null,
             obstacle: null
         }
@@ -90,6 +91,10 @@ export class Terrain extends PlaceableObject {
 
     get max() {
         return this.data.max || Terrain.defaults.max;
+    }
+    
+    get elevation() {
+        return this.data.elevation || Terrain.defaults.elevation;
     }
 
     get color() {

--- a/classes/terraindocument.js
+++ b/classes/terraindocument.js
@@ -17,6 +17,7 @@ export class TerrainData extends DocumentData {
             multiple: fields.NUMERIC_FIELD,
             min: fields.NUMERIC_FIELD,
             max: fields.NUMERIC_FIELD,
+            elevation: fields.NUMERIC_FIELD,
             drawcolor: fields.STRING_FIELD,
             environment: fields.STRING_FIELD,
             obstacle: fields.STRING_FIELD,

--- a/classes/terrainhud.js
+++ b/classes/terrainhud.js
@@ -44,6 +44,7 @@ export class TerrainHUD extends BasePlaceableHUD {
             heightclass: (this.object.min == this.object.max ? '' : 'smaller'),
             min: this.object.min,
             max: this.object.max,
+            elevation: this.object.elevation,
             environment: this.object.environment,
             environments: _environments
         });

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,7 @@
   "EnhancedTerrainLayer.ErrorCalculate": "Calculate function is undefined",
   "EnhancedTerrainLayer.Min": "Min",
   "EnhancedTerrainLayer.Max": "Max",
+  "EnhancedTerrainLayer.TerrainElevation": "Terrain Elevation",
   "EnhancedTerrainLayer.visibility": "Toggle Active State",
   "EnhancedTerrainLayer.terrain": "Terrain",
   "EnhancedTerrainLayer.Inactive": "Inactive",

--- a/templates/terrain-config.html
+++ b/templates/terrain-config.html
@@ -44,6 +44,10 @@
             <input type="number" name="max" data-dtype="Number" value="{{object.max}}">
         </div>
     </div>
+    <div class ="form-group">
+        <label for="terrainelevation">{{localize "EnhancedTerrainLayer.TerrainElevation"}}</label>
+        <input type="number" name="elevation" data-dtype="Number" value="{{object.elevation}}">
+    </div>
     <div class="form-group">
         <label for="environment">{{localize "EnhancedTerrainLayer.Environment"}}</label>
         <select name="environment" data-dtype="String">

--- a/terrain-main.js
+++ b/terrain-main.js
@@ -134,10 +134,14 @@ function addControls(app, html) {
 			)
 		
 	// add terrain elevation
-	let type = $('<div>').addClass('form-fields')
-	  .append($'<label>'.html(i18n("EnhancedTerrainLayer.TerrainElevation")))
-	  .append($('<input>').attr({ type: 'number', name: 'flags.enhanced-terrain-layer.elevation', 'data-type': 'Number' }).val(app.object.getFlag('enhanced-terrain-layer', 'elevation') || 0))
-			
+let elevation = $('<div>').addClass('form-group')
+		.append($('<label>').html(i18n("EnhancedTerrainLayer.TerrainElevation")))
+		.append($('<div>').addClass('form-fields')
+			.append($('<input>')
+				.attr({ 'type': 'number', 'data-type': 'Number', 'name': 'flags.enhanced-terrain-layer.elevation' })
+				.val(app.object.getFlag('enhanced-terrain-layer', 'elevation') || 0))
+			//.append($('<span>').addClass('range-value').css({ 'flex': '0 1 48px' }).html(multiple))
+		)			
 			/*
 			.append($('<select>')
 				.attr('name', 'flags.enhanced-terrain-layer.terraintype')
@@ -170,6 +174,7 @@ function addControls(app, html) {
 	if (ctrl.length > 0) {
 		let group = ctrl.get(0).closest(".form-group");
 		if (group) {
+                        elevation.insertAfter(group);
 			environment.insertAfter(group);
 			type.insertAfter(group);
 			cost.insertAfter(group);

--- a/terrain-main.js
+++ b/terrain-main.js
@@ -132,6 +132,12 @@ function addControls(app, html) {
 			.append($('<label>').addClass('terrainheight-label').html(i18n("EnhancedTerrainLayer.Max")))
 			.append($('<input>').attr({ type: 'number', name: 'flags.enhanced-terrain-layer.max', 'data-type': 'Number' }).val(app.object.getFlag('enhanced-terrain-layer', 'max') || 0))
 			)
+		
+	// add terrain elevation
+	let type = $('<div>').addClass('form-fields')
+	  .append($'<label>'.html(i18n("EnhancedTerrainLayer.TerrainElevation")))
+	  .append($('<input>').attr({ type: 'number', name: 'flags.enhanced-terrain-layer.elevation', 'data-type': 'Number' }).val(app.object.getFlag('enhanced-terrain-layer', 'elevation') || 0))
+			
 			/*
 			.append($('<select>')
 				.attr('name', 'flags.enhanced-terrain-layer.terraintype')


### PR DESCRIPTION
Hi! I am the module developer for [libRuler](https://github.com/caewok/fvtt-lib-ruler/) and [Elevation Ruler](https://github.com/caewok/fvtt-elevation-ruler). You can reach me on Discord at caewok#9192. Right now, Elevation Ruler looks at the maximum terrain elevation at a point to determine the default elevation when measuring to that point. But conceptually, this is not quite right, and so this PR aims to make a more conceptually consistent understanding of terrain elevation.

**Concept**
Right now, Enhanced Terrain Layer lets the user specify a min and max terrain height. If I understand this correctly, this allows the user to specify a range within which a terrain type and cost should apply. So, for example, a lake from elevation 0 to elevation -100 might be water costing double movement. Or a forest might be elevation 10 to 100, because the trees make flying more difficult. 

That makes a lot of sense, but it is not the same as elevation of the terrain. For example, you might have a plateau at elevation 20, meaning that any token just standing (not flying or burrowing) on the terrain should have elevation 20. And of course, terrain might have both an elevation and a min/max terrain height, because they indicate different things. The forest could be on the plateau, for example. In fact, you might have a terrain polygon with elevation of 20 because it is a hill but difficult terrain height at 50 to 100 because of some obstacle to flight (spiderwebs? ballons? bats?). 

**Use cases**
I have been thinking about ways to easily demarcate elevated terrain on a 2-D map. Enhanced Terrain Layer already gets 90% there, and as such doesn't require setting up an entirely different layer just to mark elevation at different points on a map. In particular, it uses closed polygons for flexibility, and also permits double-clicking at a grid point to simply mark off individual squares. Elevation also relates closely to other terrain aspects, so I think it is a good fit. 

The main use case here is letting a user mark off portions of a map that should be elevated (or decremented). The classic "king-of-the-hill" battle, or the "wandering through canyons" map. Tactical battles, for example, may find elevation a key concept. Given a consistent source of elevation information for the terrain will assist other modules. For example:

- Elevation Ruler measures in "3-D," accounting for distance moved up or down. And, if you move the token with the spacebar after measuring, it adjusts the token elevation accordingly. 
- I have a PR for [Drag Ruler](https://github.com/manuelVo/foundryvtt-drag-ruler/pull/108) that basically allows Drag Ruler to use Elevation Ruler when dragging tokens, allowing for similar distance changes.
- theripper93#3276 on Discord has several elevation-related modules, including one that calculates cover in 3-D space and volumetric area effects, and of course Levels.
- [Wall Height](https://github.com/erithtotl/FVTT-Wall-Height) works great in combination with token elevation changes, allowing tokens above or below a specified height to ignore walls. 

**What these changes do**
Basically, I just added an elevation property to Terrain class, and then changed the pop-up configuration for a terrain layer object so the user could change the elevation. I also changed the scene configuration to include an elevation setting (assuming someone might want to mark an entire map at elevation of, say, 500, with limited exceptions indicated using terrain layer. I called it "Terrain Elevation" in the UI, but I am certainly not wedded to the name.

Tested in Foundry 0.8.9 and dnd5e 1.4.2. Happy to take suggestions for better/different approaches. 

**Potential future improvements**
I was trying to keep the changes minimal. I am sure we could iterate on UI or functional improvements related to this basic concept. Some ideas for future improvements:
1. Add to your API functions to return terrain elevation at points/grid spaces. 
2. Avoid conflating "terrain height" and "terrain elevation" in functions/UI/docs. Right now, I did not mess with any of this functionality, so any function will always be using height just as it always has.
3. Remember the settings of the last user-placed polygon for a scene, and default to those when the user adds another polygon. This is particularly useful where you might have several polygons designating, say, a forest, but want to mark them with distinct elevations.
4. Display terrain elevation somewhere on the polygons when viewing them on the canvas.

