### PR TITLE
Optionally chain canvas.terrain.toolbar in updateScene hook

### DIFF
--- a/terrain-main.js
+++ b/terrain-main.js
@@ -460,7 +460,7 @@ Hooks.on("renderSceneConfig", async (app, html, data) => {
 
 Hooks.on("updateScene", (scene, data) => {
 	canvas.terrain.refresh(true);	//refresh the terrain to respond to default terrain color
-	canvas.terrain.toolbar.render(true);
+	canvas.terrain.toolbar?.render(true);
 });
 
 Hooks.on("renderItemSheet", (app, html) => {


### PR DESCRIPTION
The toolbar's presence isn't guaranteed when a scene is updated.