### PR TITLE
Remove 'getFlag' in 'get defaults' for better performance

### DIFF
--- a/classes/terrain.js
+++ b/classes/terrain.js
@@ -44,9 +44,10 @@ export class Terrain extends PlaceableObject {
     }
 
     static get defaults() {
-        let sceneMult = canvas.scene.getFlag('enhanced-terrain-layer', 'multiple');
-        let sceneElev = canvas.scene.getFlag('enhanced-terrain-layer', 'elevation');
-        let sceneDepth = canvas.scene.getFlag('enhanced-terrain-layer', 'depth');
+        const sceneFlags = canvas.scene.data.flags['enhanced-terrain-layer'];
+        let sceneMult = sceneFlags?.multiple;
+        let sceneElev = sceneFlags?.elevation;
+        let sceneDepth = sceneFlags?.depth;
         return {
             width: 0,
             height: 0,
@@ -57,7 +58,7 @@ export class Terrain extends PlaceableObject {
             multiple: (sceneMult == undefined || sceneMult == "" ? this.layer.defaultmultiple : Math.clamped(parseInt(sceneMult), setting('minimum-cost'), setting('maximum-cost'))),
             elevation: (sceneElev == undefined || sceneElev == "" ? 0 : sceneElev),
             depth: (sceneDepth == undefined || sceneDepth == "" ? 0 : sceneDepth),
-            environment: canvas.scene.getFlag('enhanced-terrain-layer', 'environment') || null,
+            environment: sceneFlags?.environment || null,
             obstacle: null
         }
     }


### PR DESCRIPTION
`getFlag` is a surprisingly expensive function for what it actually does. Modules that call the `cost` function in a hot loop can easily run into performance issues because of this. Luckily there is an alternative: Directly accessing the flag is functionally equivalent while being manifold faster.

This PR replaces the 'getFlag' function in the 'get defaults' getter with direct flag accesses to improve the performance of the `cost` function.