### PR TITLE
Use pixishape to define the hit area

### DIFF
--- a/classes/terrain.js
+++ b/classes/terrain.js
@@ -305,7 +305,7 @@ export class Terrain extends PlaceableObject {
         //this.shape.position.set(shape.width / 2, shape.height / 2);
 
         const bounds = new PIXI.Rectangle(0, 0, shape.width, shape.height).normalize();
-        this.hitArea = this.controlled ? bounds.clone().pad(50) : bounds; // Pad to include resize handle
+        this.hitArea = this.controlled ? bounds.clone().pad(50) : this.shape._pixishape; // Pad to include resize handle
         this.buttonMode = true;
         if (this.id && this.controlled) this.#refreshFrame(bounds);
         else this.frame.visible = false;
@@ -492,7 +492,7 @@ export class Terrain extends PlaceableObject {
 
 
 
-    
+
 
     /**
      * Create the components of the terrain element, the terrain container, the drawn shape, and the overlay text
@@ -582,7 +582,7 @@ export class Terrain extends PlaceableObject {
                 this.drawDashedPolygon.call(this.drawing, points, 0, 0, 0, 1, 5, 0);
                 lStyle.width = 0;
                 this.drawing.lineStyle(lStyle);
-            } 
+            }
             this.drawing.drawShape(this.shape);
         }
 


### PR DESCRIPTION
This PR addresses something I find annoying about the drawing interface---it is next to impossible to draw adjacent terrain because the hit box gets in the way.

With this modification, when a terrain is not controlled, it uses the `_pixishape` to define the hit area of the drawing. This allows users to more easily draw adjacent terrain without inadvertently clicking the existing terrain. Particularly for polygon drawings.

Some bug, maybe in the `PIXI.Ellipse` `contains` method, is causing the hit area to be the center of the ellipse. The hit area for the ellipse appears to be a small center point. Thus, to select an ellipse drawing you must  draw a small rectangle around the center. Could either fix/override the Ellipse `contains` method (assuming that is the issue) or fall back on the boundary rectangle. I leave that choice to you. 